### PR TITLE
Fix canvas scaling and prevent scrolling

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,8 +8,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const scaleCanvas = () => {
         const minSide = Math.min(window.innerWidth, window.innerHeight);
-        const scale = minSide / canvas.width;
-        canvas.style.transform = `scale(${scale})`;
+        canvas.style.width = `${minSide}px`;
+        canvas.style.height = `${minSide}px`;
     };
     window.addEventListener('resize', scaleCanvas);
     scaleCanvas();

--- a/style.css
+++ b/style.css
@@ -5,6 +5,7 @@ body, html {
     color: #0f0;
     font-family: sans-serif;
     height: 100%;
+    overflow: hidden;
 }
 
 .game-container {
@@ -13,12 +14,16 @@ body, html {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    height: 100vh;
+    width: 100vmin;
+    height: 100vmin;
+    overflow: hidden;
 }
 
 canvas {
     border: 2px solid #0f0;
     image-rendering: pixelated;
+    width: 100%;
+    height: 100%;
 }
 
 #score {


### PR DESCRIPTION
## Summary
- disable scrolling on the page
- size the game container to always be a square using `vmin`
- ensure canvas scales via width/height instead of transform

## Testing
- `npm test` *(fails: could not read package.json)*